### PR TITLE
add LMOD support

### DIFF
--- a/envreport.py
+++ b/envreport.py
@@ -64,6 +64,7 @@ class Collector:
     name: str
     path: Path
     details = False  # True to force <details> wrapper, e.g. low-priority info
+    plain_text_output = True  # if True, get_text_output is wrapped in a code fence
 
     def __init__(self, path):
         """Construct collector for path"""
@@ -302,6 +303,7 @@ class WhichCollector(Collector):
 
     level = Level.system
     name = "which"
+    plain_text_output = False
 
     commands = [
         "bash",
@@ -320,7 +322,7 @@ class WhichCollector(Collector):
     def get_text_report(self):
         """markdown list of each command path"""
         return "\n".join(
-            f"- {command}: {path}" for command, path in sorted(self.collected.items())
+            f"- {command}: `{path}`" for command, path in sorted(self.collected.items())
         )
 
 
@@ -552,9 +554,11 @@ class EnvReport:
             if details:
                 lines.append("<details>")
                 lines.append("")
-            lines.append("```")
+            if collector.plain_text_output:
+                lines.append("```")
             lines.append(text.rstrip())
-            lines.append("```")
+            if collector.plain_text_output:
+                lines.append("```")
             if details:
                 lines.append("")
                 lines.append("</details>")

--- a/envreport.py
+++ b/envreport.py
@@ -365,9 +365,16 @@ class EnvCollector(Collector):
 
     def get_text_report(self):
         """Simple env lines"""
-        return "\n".join(
-            f"{key}={value}" for key, value in sorted(self.collected.items())
-        )
+        lines = []
+        # split PATH environment variables
+        for key, value in sorted(self.collected.items()):
+            lines.append(f"{key}={value}")
+            # split path-lists for nicer diff viewing
+            # leave the long line above for easier copy/paste
+            if "PATH" in key and os.pathsep in value:
+                for item in value.split(os.pathsep):
+                    lines.append(f"#  {item}")
+        return "\n".join(lines)
 
 
 class PythonSiteCollector(CommandCollector):


### PR DESCRIPTION
Example diff run on NERSC perlmutter Jupyter environment before/after running:

```
module swap python/3.11 python/3.10
module unload gpu
```

https://gist.github.com/minrk/201f261aeb3735bf21f0acc3ed0d7cdc/revisions?source=1#diff-fa9230bd248eb5d9a681a236eda6f174a3f925ef56b547a9a68c091af638b4b8


Improvements for handling LMOD output after testing

- explode path lists
- enable Collectors to do their own markdown formatting (so they can make markdown lists, not just plaintext)
- exclude some env, like `__LMOD_REFCOUNT`